### PR TITLE
Fix bug in misclassified image visualization

### DIFF
--- a/core/cifar10_classifier.py
+++ b/core/cifar10_classifier.py
@@ -773,7 +773,7 @@ class CIFAR10Classifier:
             inset = ax.inset_axes([0.05, -0.35, 0.9, 0.3])
             inset.bar(range(len(probs[i])), probs[i], color="lightgray")
             inset.set_ylim(0, 1)
-            inset.set_xticks(range(len(prob)))
+            inset.set_xticks(range(len(probs[i])))
             inset.set_xticklabels(class_names, rotation=45, ha='right', fontsize=9)
             inset.set_yticks([0.0, 0.5, 1.0])
             inset.set_yticklabels(["0", "0.5", "1.0"], fontsize=9)


### PR DESCRIPTION
## Summary
- fix variable name in `show_misclassified`

## Testing
- `python -m py_compile core/cifar10_classifier.py`
- `python -m py_compile utils/data_utils.py utils/visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_6841e255237483238648f73232d89d73