### PR TITLE
Update checkpoint saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ pip install -r requirements.txt
 - Follow the instructions in the notebook
 - Monitor training progress in TensorBoard
 
+## 💾 Saving & Loading Models
+
+Use the helper methods on `CIFAR10Classifier` to persist models:
+
+```python
+classifier.save("path/to/model.pth")
+loaded = CIFAR10Classifier.load_model(
+    model_name, config_path, "path/to/model.pth"
+)
+```
+
+The `save()` method stores a checkpoint dictionary with a
+`model_state_dict` key, matching the format used during training.
+
 ## 📊 Model Performance
 
 Current best results:

--- a/core/cifar10_classifier.py
+++ b/core/cifar10_classifier.py
@@ -580,22 +580,32 @@ class CIFAR10Classifier:
 
     def save(self, path):
         """
-        Saves the model and its configuration to disk.
-        
+        Saves model weights to disk.
+
+        The checkpoint uses the same dictionary format produced during
+        training::
+
+            {'model_state_dict': self.model.state_dict()}
+
         Args:
             path (str): Path to save the model
         """
-        torch.save(self.model.state_dict(), path)
+        torch.save({'model_state_dict': self.model.state_dict()}, path)
 
     def load(self, path):
         """
-        Loads a saved model and its configuration from disk.
-        
+        Loads saved model weights from ``path``.
+
         Args:
             path (str): Path to load the model from
         """
-        checkpoint = torch.load(path, weights_only=False)
-        self.model.load_state_dict(checkpoint["model_state_dict"])
+        checkpoint = torch.load(path, map_location=self.device)
+        if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint:
+            state_dict = checkpoint["model_state_dict"]
+        else:
+            # Backwards compatibility with raw state dict files
+            state_dict = checkpoint
+        self.model.load_state_dict(state_dict)
         self.model.to(self.device)
 
     @classmethod


### PR DESCRIPTION
## Summary
- store a checkpoint dictionary in `save()`
- support checkpoint format and raw state dicts when loading
- document save/load helpers in README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68429d9432408323b995055ba111c58c